### PR TITLE
Moved webpack and webpack-dev-server to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,11 +14,11 @@
   "dependencies": {
     "babel-runtime": "~6.2.0",
     "react": "~0.14.3",
-    "react-dom": "~0.14.3",
-    "webpack": "~1.12.9",
-    "webpack-dev-server": "~1.14.0"
+    "react-dom": "~0.14.3"
   },
   "devDependencies": {
+    "webpack": "~1.12.9",
+    "webpack-dev-server": "~1.14.0",
     "babel-core": "~6.2.1",
     "babel-eslint": "~4.1.6",
     "babel-loader": "~6.2.0",


### PR DESCRIPTION
In the `package.json` file, I think the two packages, `webpack` and `webpack-dev-server`, are only needed during development, they are not necessary at runtime. So it's better to put them in `devDependencies`