### PR TITLE
Remove Duplicated Keyword in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,6 @@
   },
   "keywords": [
     "es6",
-    "boilerplate",
     "web app",
     "boilerplate"
   ],


### PR DESCRIPTION
Keyword `boilerplate` is duplicated in package.json