### PR TITLE
Added deploy command for Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "test": "echo \"Error: no test specified\" && exit 1",
     "build": "webpack",
     "start": "webpack-dev-server --devtool eval --progress --hot --content-base app",
-    "deploy": "NODE_ENV=production webpack -p --config webpack.production.config.js",
+    "deploy-linux": "NODE_ENV=production webpack -p --config webpack.production.config.js",
+    "deploy-windows": "SET NODE_ENV=production & webpack -p --config webpack.production.config.js",
     "validate": "npm ls",
     "commit": "git cz",
     "changelog": "conventional-changelog -p angular -i CHANGELOG.md -s -r 1"


### PR DESCRIPTION
Setting env variable is slightly different on Windows and Linux so Windows users could not use "npm run deploy" to compile the project, I added a command named "deploy-windows" and renamed the old command to "deploy-linux"