### PR TITLE
Add plugin to `webpack.production.config.js` in order to solve a depl…

### DIFF
--- a/webpack.production.config.js
+++ b/webpack.production.config.js
@@ -29,6 +29,11 @@ module.exports = {
         warnings: false
       }
     }),
+    new webpack.DefinePlugin({
+      'process.env': {
+        NODE_ENV: JSON.stringify('production')
+      }
+    }),
     new CopyWebpackPlugin([
       { from: './app/index.html', to: 'index.html' },
       { from: './app/main.css', to: 'main.css' }


### PR DESCRIPTION
Add plugin to `webpack.production.config.js` in order to solve a deploy warning.

Warning description:
"Warning: It looks like you're using a minified copy of the development build of React."