### PR TITLE
移除 script 中多余的 deploy-windows 方法

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,8 +9,7 @@
     "test": "echo \"Error: no test specified\" && exit 1",
     "build": "webpack",
     "start": "webpack-dev-server --devtool eval --progress --hot --content-base app",
-    "deploy": "NODE_ENV=production webpack -p --config webpack.production.config.js",
-    "deploy-windows": "SET NODE_ENV=production & webpack -p --config webpack.production.config.js",
+    "deploy": "webpack --config webpack.production.config.js",
     "validate": "npm ls",
     "commit": "git cz",
     "changelog": "conventional-changelog -p angular -i CHANGELOG.md -s -r 1"


### PR DESCRIPTION
执行 shell 命令时传入的 NODE_ENV 环境变量是传给 webpack 命令的，和被打包的代码无关，所以 `deploy` 命令前面的 NODE_ENV 是完全没必要的，真正起作用的是  DefinePlugin 中定义的环境变量。

另外，webpack 的 `-p` 参数与配置文件中的 UglifyPlugin 的功能重合，会报错。 